### PR TITLE
Add and adjust some rules

### DIFF
--- a/syntax/cocci.vim
+++ b/syntax/cocci.vim
@@ -18,10 +18,13 @@ syn region CocciGroup matchgroup=CocciGroupDelim start="^@[^@:]*@" end="@@" cont
 
 syn match CocciInlineScript     "script\s*:\s*\(python\|ocaml\)\s*([^)]*)\s*{[^}]*}" contained
 
-syn match CocciLineRemoved      "^-.*"
-syn match CocciLineAdded        "^+.*"
+syn region CocciLineRemoved start="^-"  end="$" keepend contains=CocciOperator,CocciPosition
+syn region CocciLineAdded   start="^+"  end="$" keepend contains=CocciOperator,CocciPosition
+syn region CocciLinePinned  start="^\*" end="$" keepend contains=CocciOperator,CocciPosition
+
 syn match CocciComment          "//.*"
 
+syn match CocciPosition         "\%(^\)\@!@[_a-zA-Z][_a-zA-Z0-9]*"
 syn match CocciOperator         "\.\.\."
 syn match CocciOperator         "<\.\.\."
 syn match CocciOperator         "\.\.\.>"
@@ -36,8 +39,10 @@ syn case match
 syn match CocciError            "^[ \t][+-].*"
 
 " Highlight!
+hi def link CocciPosition       Directory
 hi def link CocciLineRemoved    Special
 hi def link CocciLineAdded      Identifier
+hi def link CocciLinePinned     NonText
 hi def link CocciError          Error
 hi def link CocciKeywords       Type
 hi def link CocciGroupDelim     PreProc

--- a/syntax/cocci.vim
+++ b/syntax/cocci.vim
@@ -14,7 +14,7 @@ syn keyword CocciKeywords       statement function local list fresh position ide
 syn keyword CocciKeywords       declaration declarer attribute symbol format assignment contained
 syn keyword CocciKeywords       operator global field initializer initialiser iterator name contained
 
-syn region CocciGroup matchgroup=CocciGroupDelim start="^@[^@:]*@" end="@@" contains=CocciKeywords
+syn region CocciGroup matchgroup=CocciGroupDelim start="^@[^@:]*@" end="@@" contains=CocciKeywords,CocciComment
 
 syn match CocciLineRemoved      "^-.*"
 syn match CocciLineAdded        "^+.*"

--- a/syntax/cocci.vim
+++ b/syntax/cocci.vim
@@ -20,8 +20,12 @@ syn match CocciLineRemoved      "^-.*"
 syn match CocciLineAdded        "^+.*"
 syn match CocciComment          "//.*"
 
-syn case ignore
 syn match CocciOperator         "\.\.\."
+syn match CocciOperator         "<\.\.\."
+syn match CocciOperator         "\.\.\.>"
+syn match CocciOperator         "<+\.\.\."
+syn match CocciOperator         "\.\.\.+>"
+syn case ignore
 syn match CocciOperator         "when"
 syn match CocciOperator         "any"
 syn case match

--- a/syntax/cocci.vim
+++ b/syntax/cocci.vim
@@ -8,6 +8,21 @@ if &compatible || v:version < 603 || exists("b:current_syntax")
     finish
 endif
 
+" Highlighting python and ocaml blocks
+syn include @PythonSyntax syntax/python.vim
+syn include @OCamlSyntax syntax/ocaml.vim
+
+syn region CocciPythonBlock matchgroup=CocciCodeBlock
+    \ start=+^@\s*\(script\|initialize\|finalize\)\s*:\s*python\s*[^@]*@\(\n.*<<.*\)*\_s*@@+
+    \ skip=+^$+
+    \ end=+^\([^@/]\)\@!+
+    \ contains=@PythonSyntax
+syn region CocciOCamlBlock matchgroup=CocciCodeBlock
+    \ start=+@\s*\(script\|initialize\|finalize\)\s*:\s*ocaml\s*[^@]*@\(\n.*<<.*\)*\_s*@@+
+    \ skip=+^$+
+    \ end=+^\(\s*[^@/]\)\@!+
+    \ contains=@OCamlSyntax
+
 " Keywords
 syn keyword CocciKeywords       identifier type parameter constant expression contained
 syn keyword CocciKeywords       statement function local list fresh position idexpression contained
@@ -49,6 +64,7 @@ hi def link CocciGroupDelim     PreProc
 hi def link CocciComment        Comment
 hi def link CocciOperator       Operator
 hi def link CocciInlineScript   Special
+hi def link CocciCodeBlock      PreProc
 
 let b:current_syntax = "cocci"
 

--- a/syntax/cocci.vim
+++ b/syntax/cocci.vim
@@ -14,7 +14,9 @@ syn keyword CocciKeywords       statement function local list fresh position ide
 syn keyword CocciKeywords       declaration declarer attribute symbol format assignment contained
 syn keyword CocciKeywords       operator global field initializer initialiser iterator name contained
 
-syn region CocciGroup matchgroup=CocciGroupDelim start="^@[^@:]*@" end="@@" contains=CocciKeywords,CocciComment
+syn region CocciGroup matchgroup=CocciGroupDelim start="^@[^@:]*@" end="@@" contains=CocciKeywords,CocciComment,CocciInlineScript
+
+syn match CocciInlineScript     "script\s*:\s*\(python\|ocaml\)\s*([^)]*)\s*{[^}]*}" contained
 
 syn match CocciLineRemoved      "^-.*"
 syn match CocciLineAdded        "^+.*"
@@ -41,6 +43,7 @@ hi def link CocciKeywords       Type
 hi def link CocciGroupDelim     PreProc
 hi def link CocciComment        Comment
 hi def link CocciOperator       Operator
+hi def link CocciInlineScript   Special
 
 let b:current_syntax = "cocci"
 

--- a/syntax/cocci.vim
+++ b/syntax/cocci.vim
@@ -33,7 +33,7 @@ syn match CocciError            "^[ \t][+-].*"
 hi def link CocciLineRemoved    Special
 hi def link CocciLineAdded      Identifier
 hi def link CocciError          Error
-hi def link CocciKeywords       Keyword
+hi def link CocciKeywords       Type
 hi def link CocciGroupDelim     PreProc
 hi def link CocciComment        Comment
 hi def link CocciOperator       Operator

--- a/syntax/cocci.vim
+++ b/syntax/cocci.vim
@@ -14,7 +14,7 @@ syn keyword CocciKeywords       statement function local list fresh position ide
 syn keyword CocciKeywords       declaration declarer attribute symbol format assignment contained
 syn keyword CocciKeywords       operator global field initializer initialiser iterator name contained
 
-syn region CocciGroup matchgroup=CocciGroupDelim start="@[^@]*@" end="@@" contains=CocciKeywords
+syn region CocciGroup matchgroup=CocciGroupDelim start="^@[^@:]*@" end="@@" contains=CocciKeywords
 
 syn match CocciLineRemoved      "^-.*"
 syn match CocciLineAdded        "^+.*"


### PR DESCRIPTION
Adds:
1. highlighting `<...`, `...>`, `<+...`, and `...+>`
2. highlighting inline scripts as constraints in a meta-block
3. highlighting the python and ocmal blocks with corresponding syntax
4. highlighting the position objects in a transformation

Adjusts:
1. adjust the color for the keywords in a meta-block (the color of keywords -> types)
2. adjust the rule matching the start of meta-blocks: avoiding the rule matching the position objects inside transformation blocks
3. matching the comments inside a meta-block

All adjusted and added rules are separated in a commit each.